### PR TITLE
Add hacking section to README, fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ $ fastpac
 
 ## Hacking
 
-Contributions are welcome! All new code should be tested using our pytest
-testing system, which you can run with the shell command `py.test` in
-the root of the repository.
+Contributions are welcome! We use pytest for testing all new code added to
+fastpac, which you can use to test the codebase by running `py.test`.
+
+To set up a development environment, run the following commands:
+
+```
+$ pip install --user -e .[dev]  # install all the fastpac deps including dev to user profile
+$ py.test  # run test suite to make sure everything is ok
+```
+

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Parallel pacman package downloader
 Create requisite directories and set up config file:
 
 ```
-# python setup.py install
+# python3 setup.py install
 # useradd -r fastpac
 # mkdir -p /var/cache/fastpac/{pkg,pkglists}
 # chown -R fastpac:fastpac /var/cache/fastpac

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Parallel pacman package downloader
 ## Manual installation (packaging to follow)
 Create requisite directories and set up config file:
 
-```bash
+```
+# python setup.py install
 # useradd -r fastpac
 # mkdir -p /var/cache/fastpac/{pkg,pkglists}
 # chown -R fastpac:fastpac /var/cache/fastpac
@@ -13,8 +14,14 @@ Create requisite directories and set up config file:
 
 ## Usage
 
-```bash
+```
 # su fastpac
 $ pacman -Q > "/var/cache/fastpac/packagelists/$(hostname)"
 $ fastpac
 ```
+
+## Hacking
+
+Contributions are welcome! All new code should be tested using our pytest
+testing system, which you can run with the shell command `py.test` in
+the root of the repository.

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,17 @@
 from distutils.core import setup
 
-setup(name='fastpac',
-        description='Arch Linux package downloader',
-        version='0.1',
-        author='Quinn Parrott',
-        url='https://github.com/parrottq/fastpac',
-        packages=['fastpac'],
-        install_requires=['requests'],
-        license='GPL3'
-        )
+setup(
+    name='fastpac',
+    description='Arch Linux package downloader',
+    version='0.1',
+    author='Quinn Parrott',
+    url='https://github.com/parrottq/fastpac',
+    packages=['fastpac'],
+    install_requires=['requests'],
+    extras_require={
+        'dev': [
+            'pytest',
+        ],
+    },
+    license='GPL3'
+)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='fastpac',


### PR DESCRIPTION
I also did a bad thing and reformatted the `setup.py` and switched it to setuptools instead of distutils (it was actually using setuptools features without using setuptools which was definitely a bug).