### PR TITLE
Update readme for friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 Parallel pacman package downloader
 
 ## Manual installation (packaging to follow)
+This package needs python 3.6 or later.
+
 Create requisite directories and set up config file:
 
 ```
 # python3 setup.py install
-# useradd -r fastpac
+# useradd --system fastpac
 # mkdir -p /var/cache/fastpac/{pkg,pkglists}
 # chown -R fastpac:fastpac /var/cache/fastpac
 # cp config.py /etc/fastpac.conf.py
@@ -28,7 +30,7 @@ fastpac, which you can use to test the codebase by running `py.test`.
 To set up a development environment, run the following commands:
 
 ```
-$ pip install --user -e .[dev]  # install all the fastpac deps including dev to user profile
+$ pip install --user -e .[dev]  # install all the fastpac deps to user profile, including dev deps
 $ py.test  # run test suite to make sure everything is ok
 ```
 


### PR DESCRIPTION
We need to note that `fastpac` requires python 3.6, which many obsolete distros such as the current version of Debian Stable doesn't have. Also, change some command line arguments which aren't super well known to use long options.